### PR TITLE
Add a user friendly view of the docs

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,6 @@ class App {
         const NF = new pipes.UnknownEndpointPipeline(db, logger);
 
         // one pipeline instance per endpoint
-        const Index = NA;
         const RegenerateToken = NA;
         const CreateAccount = NA; // CreateEntity (in question - see issue #25)
         const CloseAccount = NA; // CloseEntity
@@ -30,9 +29,11 @@ class App {
         const CreateMessage = NA; // CreateEntity
         const ListConversation = NA; // SearchEntity
         const ViewConversation = NA; // ViewEntity
+
+        // serve the docs directory statically, so the index page becomes the API docs
+        app.use(express.static('docs'));
         
         // connect endpoints to their relevant pipeline instances
-        app.get('/', Index.Execute);
         app.post('/token/regeneration', RegenerateToken.Execute);
         
         app.post('/account/create', CreateAccount.Execute);

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>AR Reshare API specification</title>
+  
+    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+  </head>
+  <body>
+
+    <elements-api
+      apiDescriptionUrl="/oas.yaml"
+      router="hash"
+    />
+
+  </body>
+</html>
+


### PR DESCRIPTION
It's dynamic, so we won't have to recompile it or anything if/when the docs change. It's currently served from the index page, but can be moved.

Uses [Elements](https://meta.stoplight.io/docs/elements/ZG9jOjEyMDU2Njc1-hello-world-example)