### PR TITLE
Remove 409 from create-conversation and return existing conversation …

### DIFF
--- a/docs/oas.yaml
+++ b/docs/oas.yaml
@@ -427,8 +427,6 @@ paths:
           $ref: 'responses.yaml#/components/responses/unauthorised'
         '404': # Not Found
           $ref: 'responses.yaml#/components/responses/not-found'
-        '409': # Conflict
-          $ref: 'responses.yaml#/components/responses/conflict-create'
       requestBody:
         $ref: 'requestBodies.yaml#/components/requestBodies/conversation-create'
 

--- a/docs/responses.yaml
+++ b/docs/responses.yaml
@@ -169,7 +169,7 @@ components:
 
 
     conversation-create:
-      description: The conversation has been initiated
+      description: The conversation has been initiated, or an identical conversation was found. Either way, the ID is returned
       content:
         'application/json':
           schema:

--- a/schemas/sql-templates.js
+++ b/schemas/sql-templates.js
@@ -381,7 +381,7 @@ const CloseListingTemplate = new SQLTemplate({
 
 const CreateConversationTemplate = new SQLTemplate({
     create_conversation: {
-        text: 'INSERT INTO Conversation (ReceiverID, ListingID) SELECT $1, $2 WHERE EXISTS (SELECT 1 FROM Listing WHERE ListingID = $2 AND ClosedDate IS NULL AND ContributorID != $1) RETURNING ConversationID',
+        text: 'WITH e AS (INSERT INTO Conversation (ReceiverID, ListingID) SELECT $1, $2 WHERE EXISTS (SELECT 1 FROM Listing WHERE ListingID = $2 AND ClosedDate IS NULL AND ContributorID != $1) ON CONFLICT(ReceiverID, ListingID) DO NOTHING RETURNING ConversationID) SELECT * FROM e UNION SELECT ConversationID FROM Conversation WHERE ReceiverID = $1 AND ListingID = $2',
         values: [
             {from_input: 'accountID'},
             {from_input: 'listingID'},

--- a/tests/system/sys10a.createconversation.test.js
+++ b/tests/system/sys10a.createconversation.test.js
@@ -106,7 +106,8 @@ describe('System Test 10 - /conversation/create', () => {
             .put('/conversation/create')
             .set('Authorization', token)
             .send(data)
-            .expect(409);
+            .expect(201)
+            .expect({success: 1});
     });
     
     test('Class 8: ID matches a listing this user created', () => {


### PR DESCRIPTION
…ID instead

Resolving #72 . Including the ID in the error response was too difficult with our pipeline implementation (all information would have to be carried in the error message) so we just fail silently and pretend it's supposed to do that.

Note: there is an actual good reason to do it this way, mostly because the front-end doesn't actually care whether the conversation is new or existing anyway.